### PR TITLE
v1.3.2

### DIFF
--- a/NetCorePal.HealthCheck.Redis/NetCorePal.HealthCheck.Redis.csproj
+++ b/NetCorePal.HealthCheck.Redis/NetCorePal.HealthCheck.Redis.csproj
@@ -10,6 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcorepal healthcheck redis stackexchange</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageReleaseNotes>fix:Redis PackageReference Version</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="1.2.0" />
@@ -20,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="StackExchange.Redis" Version="2.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.495" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCorePal.HealthCheck/HealthChecker.cs
+++ b/NetCorePal.HealthCheck/HealthChecker.cs
@@ -21,7 +21,7 @@ namespace NetCorePal.HealthCheck
         /// <returns></returns>
         public virtual async Task<HealthCheckResult> CheckAsync()
         {
-            return await Task.Factory.StartNew(Check).ConfigureAwait(false);
+            return await Task.FromResult(Check()).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/NetCorePal.HealthCheck/NetCorePal.HealthCheck.csproj
+++ b/NetCorePal.HealthCheck/NetCorePal.HealthCheck.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>netcorepal</Company>
     <Authors>netcorepal</Authors>
-    <PackageReleaseNotes>empty string use default value in provider name of connection string</PackageReleaseNotes>
+    <PackageReleaseNotes>improve: use Task.FromResult instead of Task.Factory.StartNew in HealthChecker.CheckAsync</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/netcorepal/healthcheck</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/netcorepal/healthcheck.git</RepositoryUrl>

--- a/build/version.props
+++ b/build/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
improve: use Task.FromResult instead of Task.Factory.StartNew in HealthChecker.CheckAsync
fix:Redis PackageReference Version